### PR TITLE
Improve auto backlight brightness

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -199,10 +199,18 @@
 
          Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
+        <item>2</item>
+        <item>7</item>
         <item>15</item>
-        <item>150</item>
+        <item>50</item>
+        <item>100</item>
+        <item>200</item>
+        <item>400</item>
         <item>1000</item>
+        <item>2000</item>
+        <item>3000</item>
         <item>5000</item>
+        <item>10000</item>
     </integer-array>
 
     <!-- Array of output values for LCD backlight corresponding to the LUX values
@@ -210,27 +218,38 @@
          than the size of the config_autoBrightnessLevels array.
          This must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>50</item>
-        <item>80</item>
-        <item>162</item>
-        <item>190</item>
-        <item>255</item>
+        <item>12</item>   <!-- 0-2 -->
+        <item>22</item>   <!-- 3-7 -->
+        <item>32</item>   <!-- 5-15 -->
+        <item>42</item>   <!-- 15-50 -->
+        <item>52</item>   <!-- 50-100 -->
+        <item>62</item>   <!-- 100-200 -->
+        <item>72</item>   <!-- 200-400 -->
+        <item>82</item>   <!-- 400-1000 -->
+        <item>96</item>   <!-- 1000-2000 -->
+        <item>134</item>  <!-- 2000-3000 -->
+        <item>178</item>  <!-- 3000-5000 -->
+        <item>225</item>  <!-- 5000-10000 -->
+        <item>255</item>  <!-- 10000+ -->
     </integer-array>
 
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
-    <integer name="config_screenBrightnessSettingMinimum">20</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
 
-    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <!-- Minimum allowable screen brightness to use in a very dark room.
+         This value sets the floor for the darkest possible auto-brightness
+         adjustment.  It is expected to be somewhat less than the first entry in
+         config_autoBrightnessLcdBacklightValues so as to allow the user to have
+         some range of adjustment to dim the screen further than usual in very
+         dark rooms. The contents of the screen must still be clearly visible
+         in darkness (although they may not be visible in a bright room). -->
+    <integer name="config_screenBrightnessDark">2</integer>
 
-    <!-- Default screen brightness setting.
-         Must be in the range specified by minimum and maximum. -->
-    <integer name="config_screenBrightnessSettingDefault">117</integer>
-
-    <!-- Screen brightness used to dim the screen when the user activity
-         timeout expires.  May be less than the minimum allowed brightness setting
-         that can be set by the user. -->
-    <integer name="config_screenBrightnessDim">14</integer>
+    <!-- Initial light sensor event rate in milliseconds for automatic brightness control. This is
+         used for obtaining the first light sample when the device stops dozing.
+         Set this to 0 to disable this feature. -->
+    <integer name="config_autoBrightnessInitialLightSensorRate">50</integer>
 
     <!-- Boolean to enable stk functionality on Samsung phones -->
 <!--    <bool name="config_samsung_stk">true</bool> -->


### PR DESCRIPTION
Adjust and cleanup backlight brightness values
Make the autoBrightnessLcdBacklightValues values slightly darker
Remove values that allready have proper default values

Set config_autoBrightnessInitialLightSensorRate so the initial call to handleLightSensorEvent() will happen after a delay, to avoid screen brightness ramp-up due to sensor reporting 0 lux.
Set config_screenBrightnessDark as the default value of 1 causes the screen to black-out